### PR TITLE
fix Wasm casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 `neo` is the module for working with matrices, ndarrays, tensors and linear
-algebra in deno. Accelerated using WebGPU and WASM it runs anywhere a browser
+algebra in deno. Accelerated using WebGPU and Wasm it runs anywhere a browser
 runs.
 
 ## Maintainers

--- a/benchmarks/binary.ts
+++ b/benchmarks/binary.ts
@@ -39,7 +39,7 @@ for (let i = 64; i < 128; i += 8) {
     b.dispose();
     c.dispose();
   });
-  // WASM
+  // Wasm
   Deno.bench(`wasm ${i} * ${i}`, {
     group: `${i} * ${i}`,
   }, async () => {

--- a/benchmarks/matmul.ts
+++ b/benchmarks/matmul.ts
@@ -39,7 +39,7 @@ for (let i = 64; i < 128; i += 8) {
     b.dispose();
     c.dispose();
   });
-  // WASM
+  // Wasm
   Deno.bench(`wasm ${i} * ${i}`, {
     group: `${i} * ${i}`,
   }, async () => {

--- a/benchmarks/transpose.ts
+++ b/benchmarks/transpose.ts
@@ -33,7 +33,7 @@ for (let i = 64; i < 128; i += 8) {
     a.dispose();
     b.dispose();
   });
-  // WASM
+  // Wasm
   Deno.bench(`wasm ${i} * ${i}`, {
     group: `${i} * ${i}`,
   }, async () => {

--- a/benchmarks/unary.ts
+++ b/benchmarks/unary.ts
@@ -33,7 +33,7 @@ for (let i = 64; i <= 128; i += 8) {
     a.dispose();
     b.dispose();
   });
-  // WASM
+  // Wasm
   Deno.bench(`wasm ${i} * ${i}`, {
     group: `${i} * ${i}`,
   }, async () => {


### PR DESCRIPTION
fix Wasm casing WebAssembly is abbreviated Wasm (instead of WASM). Source https://webassembly.org/. This change replaces the upper casing used in the codebase.

WASM is also in the repository description.